### PR TITLE
fix: Update issue #602 notebook to install from fix branch

### DIFF
--- a/nba_api_issue_validations/issue_602_boxscore_normalized_methods.ipynb
+++ b/nba_api_issue_validations/issue_602_boxscore_normalized_methods.ipynb
@@ -3,32 +3,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# GitHub Issue #602 Validation\n",
-    "\n",
-    "**Issue**: [BoxScoreTraditionalV3 & V2 returns blank value when using get_normalized_(x) functions](https://github.com/swar/nba_api/issues/602)\n",
-    "\n",
-    "**Reported Problem**: The `BoxScoreTraditionalV3` endpoint works fine with standard methods, but `get_normalized_json()` and `get_normalized_dict()` return empty values.\n",
-    "\n",
-    "**This notebook validates**: Whether the normalized methods work correctly or return empty values.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/brandonhawi/playground/blob/main/nba_api_issue_validations/issue_602_boxscore_normalized_methods.ipynb)\n",
-    "\n",
-    "**To run this notebook**: Click \"Runtime\" → \"Run all\" in the menu above"
-   ]
+   "source": "# GitHub Issue #602 Validation\n\n**Issue**: [BoxScoreTraditionalV3 & V2 returns blank value when using get_normalized_(x) functions](https://github.com/swar/nba_api/issues/602)\n\n**Reported Problem**: The `BoxScoreTraditionalV3` endpoint works fine with standard methods, but `get_normalized_json()` and `get_normalized_dict()` return empty values.\n\n**This notebook validates**: Whether the normalized methods work correctly with the fix applied.\n\n---\n\n[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/brandonhawi/playground/blob/main/nba_api_issue_validations/issue_602_boxscore_normalized_methods.ipynb)\n\n**To run this notebook**: Click \"Runtime\" → \"Run all\" in the menu above\n\n**Note**: This notebook installs nba_api from the fix branch to demonstrate the resolved issue."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Install nba_api if not already installed\n",
-    "!pip install -q nba_api pandas\n",
-    "print(\"Dependencies installed\")"
-   ]
+   "source": "# Install nba_api with the fix from GitHub branch\nprint(\"Installing nba_api with fix from branch fix/issue-602-normalized-methods...\")\n!pip install -q git+https://github.com/brandonhawi/nba_api.git@fix/issue-602-normalized-methods\n!pip install -q pandas\nprint(\"✅ Dependencies installed with fix!\")"
   },
   {
    "cell_type": "markdown",
@@ -239,23 +221,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "---\n",
-    "## Conclusion\n",
-    "\n",
-    "### Summary\n",
-    "\n",
-    "This notebook validates whether issue #602 exists or has been resolved:\n",
-    "\n",
-    "- If `get_normalized_dict()` and `get_normalized_json()` return empty values: **Issue EXISTS**\n",
-    "- If they return data: **Issue RESOLVED**\n",
-    "\n",
-    "Check the test results above to see the current status.\n",
-    "\n",
-    "---\n",
-    "*Tested with nba_api latest version*  \n",
-    "*Test date: December 2024*"
-   ]
+   "source": "---\n## Conclusion\n\n### Summary\n\nThis notebook validates the fix for issue #602:\n\n- **Issue #602**: `get_normalized_dict()` and `get_normalized_json()` returned empty values for V3 endpoints\n- **Fix**: PR #606 adds support for V3 endpoints in normalized methods\n- **Expected Result**: Both methods should now return data\n\nCheck the test results above:\n- ✅ If `get_normalized_dict()` and `get_normalized_json()` return data: **Fix is WORKING**\n- ❌ If they return empty values: **Fix needs adjustment**\n\n### Fix Details\n\nThe fix is implemented in PR [#606](https://github.com/swar/nba_api/pull/606):\n- Stores endpoint name in `NBAStatsResponse`\n- Uses custom parsers for V3 endpoints\n- Converts parsed data to normalized format\n\n---\n*Tested with nba_api from fix branch: `brandonhawi/nba_api@fix/issue-602-normalized-methods`*  \n*Test date: December 2024*"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Quick fix to update the validation notebook to install nba_api from the fix branch.

This was missed in the previous PR - the notebook needs to install from `brandonhawi/nba_api@fix/issue-602-normalized-methods` to demonstrate the fix working.